### PR TITLE
Fixes for PULP Cluster

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -135,7 +135,7 @@ packages:
     dependencies:
     - common_cells
   hci:
-    revision: f7fbfcd3bf4a4c27b03119381329aec0716d2a8a
+    revision: 2a5a5081a2b32f1a04e7e28c00d3762d92602b84
     version: null
     source:
       Git: https://github.com/pulp-platform/hci.git

--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,8 @@ sw-clean:
 	@rm -rf pulp-runtime fault_injection_sim regression_tests
 
 ## Clone pulp-runtime as SW stack
-PULP_RUNTIME_REMOTE ?= git@github.com:FondazioneChipsIT/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 093ec1f95302c2c616a7b52336248ee30d40b1b8 # branch: lg/upstream
+PULP_RUNTIME_REMOTE ?= https://github.com/FondazioneChipsIT/pulp-runtime.git
+PULP_RUNTIME_COMMIT ?= 093ec1f # branch: new_iDMA_tests
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@
@@ -98,8 +98,8 @@ fault_injection_sim:
 	cd $@ && git checkout $(FAULT_SIM_COMMIT)
 
 ## Clone regression tests
-REGRESSION_TESTS_REMOTE ?= git@github.com:FondazioneChipsIT/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= 6fac940e924c7de83b37d7be14bfd9febbf04678 # branch: new_iDMA_tests
+REGRESSION_TESTS_REMOTE ?= https://github.com/FondazioneChipsIT/regression_tests.git
+REGRESSION_TESTS_COMMIT ?= c9fcb90 # branch: new_iDMA_tests
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ VLIB ?= $(QUESTA) vlib
 QSIM ?= $(QUESTA) qsim
 QOPT ?= $(QUESTA) qopt
 Q1VE ?= q1ve --qverify
-BENDER_GIT_DIR=$(ROOT_DIR)/.bender/git/checkouts
+
+VENV  := venv
 
 top_level ?= pulp_cluster
 library ?= work
@@ -133,8 +134,13 @@ scripts/compile_lint.tcl:
 $(library):
 	$(QUESTA) vlib $(library)
 
-generate_idma_rtl:
-	$(MAKE) -C $(shell find $(BENDER_GIT_DIR) -type d -name 'idma*' | head -n 1) idma_hw_all
+venv:
+	python3 -m venv $(VENV) && \
+	$(VENV)/bin/python -m pip install -U pip && \
+	$(VENV)/bin/python -m pip install -r $(shell bender path idma)/requirements.txt
+
+generate_idma_rtl: venv
+	. "$(VENV)/bin/activate" && $(MAKE) -C $(shell bender path idma) idma_hw_all
 
 compile: $(library)
 	@test -f Bender.lock || { echo "ERROR: Bender.lock file does not exist. Did you run make checkout in bender mode?"; exit 1; }


### PR DESCRIPTION
This PR introduces various fixes for PULP Cluster.

- Add venv target to ease iDMA RTL generation
- Fix Bender.lock to point to right commit (master's last commit breaks HWPEs)
- Bump regression test to include a pulp_cluster target for local regression test execution
- Use HTTPS remotes instead of SSH ones (no SSH-key prerequisites in this way)