### PR TITLE
tb: Fix timeunit to ns and change clock value to 500MHz

### DIFF
--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -14,7 +14,7 @@
 //              the virtual interfaces and starts the test passed by +UVM_TEST+
 //`define TEST_CLOCK_BYPASS
 
-`timescale 1ps/1ps
+`timescale 1ns/1ps
 
 `include "pulp_soc_defines.sv"
 `include "axi/assign.svh"
@@ -35,9 +35,9 @@ module pulp_cluster_tb;
   logic s_rstn;
   logic s_rstn_cl;
 
-  localparam time SYS_TCK  = 8ns;
-  localparam time SYS_TA   = 2ns;
-  localparam time SYS_TT   = SYS_TCK - 2ns;
+  localparam time SYS_TCK  = 2ns;
+  localparam time SYS_TA   = 0.5ns;
+  localparam time SYS_TT   = SYS_TCK - 0.5ns;
 
   clk_rst_gen #(
     .ClkPeriod    ( SYS_TCK ),


### PR DESCRIPTION
* Due to a mismatch between the testbench and Makefile, the clock timeunit was in us instead of ns