### PR TITLE
Improve HMR parametrization and fix mock UART address map in testbench

### DIFF
--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1036,40 +1036,53 @@ generate
   end
 endgenerate
 
-logic [Cfg.NumCores/3-1:0] hmr_tmr_synch;
-for (genvar i = 0; i < Cfg.NumCores/3; i++) begin
-  if (1'b1) begin // InterleaveGrps
-    assign hmr_tmr_synch[i] = hmr_barrier_matched[i + 1];
-  end else begin
-    assign hmr_tmr_synch[i] = hmr_barrier_matched[i + i/2 + 1];
-  end
-end
-
-logic [Cfg.NumCores/3-1:0] hmr_tmr_sw_resynch_req_short;
-logic [Cfg.NumCores/2-1:0] hmr_dmr_sw_resynch_req_short;
-always_comb begin
-  hmr_tmr_sw_resynch_req = '0;
-  hmr_dmr_sw_resynch_req = '0;
-
-  for (int i = 0; i < Cfg.NumCores/3; i++) begin
-    if (1'b1) begin // InterleaveGrps
-      hmr_tmr_sw_resynch_req[i] = hmr_tmr_sw_resynch_req_short[i];
-    end else begin
-      hmr_tmr_sw_resynch_req[3*i] = hmr_tmr_sw_resynch_req_short[i];
-    end
-  end
-
-  for (int i = 0; i < Cfg.NumCores/2; i++) begin
-    if (1'b1) begin // InterleaveGrps
-      hmr_dmr_sw_resynch_req[i] = hmr_dmr_sw_resynch_req_short[i];
-    end else begin
-      hmr_dmr_sw_resynch_req[2*i] = hmr_dmr_sw_resynch_req_short[i];
-    end
-  end
-end
-
 generate
   if (Cfg.HMRPresent) begin : gen_hmr_unit
+
+    localparam int unsigned NumTMRGroups   = Cfg.HMRTmrEnabled ? NumCores/3 : 1;
+    localparam int unsigned NumDMRGroups   = Cfg.HMRDmrEnabled ? NumCores/2 : 1;
+
+    logic [NumTMRGroups-1:0] hmr_tmr_synch;
+    logic [NumTMRGroups-1:0] hmr_tmr_sw_resynch_req_short;
+    logic [NumDMRGroups-1:0] hmr_dmr_sw_resynch_req_short;
+
+
+    if (Cfg.HMRTmrEnabled) begin : gen_hmr_tmr_synch
+      for (genvar i = 0; i < Cfg.NumCores/3; i++) begin
+        if (1'b1) begin // InterleaveGrps
+          assign hmr_tmr_synch[i] = hmr_barrier_matched[i + 1];
+        end else begin
+          assign hmr_tmr_synch[i] = hmr_barrier_matched[i + i/2 + 1];
+        end
+      end
+
+      always_comb begin
+        hmr_tmr_sw_resynch_req = '0;
+        for (int i = 0; i < Cfg.NumCores/3; i++) begin
+          if (1'b1) begin // InterleaveGrps
+            hmr_tmr_sw_resynch_req[i] = hmr_tmr_sw_resynch_req_short[i];
+          end else begin
+            hmr_tmr_sw_resynch_req[3*i] = hmr_tmr_sw_resynch_req_short[i];
+          end
+        end
+      end
+
+    end else begin : gen_no_hmr_tmr_synch
+      assign hmr_tmr_synch = '0;
+      assign hmr_tmr_sw_resynch_req = '0;
+    end
+
+    always_comb begin
+      hmr_dmr_sw_resynch_req = '0;
+      for (int i = 0; i < Cfg.NumCores/2; i++) begin
+        if (1'b1) begin // InterleaveGrps
+          hmr_dmr_sw_resynch_req[i] = hmr_dmr_sw_resynch_req_short[i];
+        end else begin
+          hmr_dmr_sw_resynch_req[2*i] = hmr_dmr_sw_resynch_req_short[i];
+        end
+      end
+    end
+
     hmr_unit #(
       .NumCores          ( Cfg.NumCores                         ),
       .DMRSupported      ( Cfg.HMRDmrEnabled                    ),
@@ -1122,11 +1135,19 @@ generate
       .core_bus_outputs_i     ( '0           ),
       .core_axi_outputs_i     ( '0           )
     );
+
+    `ifndef VERILATOR
+    initial begin: p_assertions
+      assert (Cfg.HMRPresent && (Cfg.HMRDmrEnabled || Cfg.HMRTmrEnabled))
+          else $fatal(1, "Either DMR or TMR must be enabled when HMR is present!");
+    end
+    `endif
+
   end else begin : gen_no_hmr_unit
     assign hmr_reg_rsp                  = '0;
-    assign hmr_tmr_sw_resynch_req_short = '0;
     assign hmr_tmr_sw_synch_req         = '0;
-    assign hmr_dmr_sw_resynch_req_short = '0;
+    assign hmr_tmr_sw_resynch_req       = '0;
+    assign hmr_dmr_sw_resynch_req       = '0;
     assign hmr_dmr_sw_synch_req         = '0;
     assign recovery_bus                 = '0;
     assign setback                      = '0;

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -64,6 +64,8 @@ module pulp_cluster_tb;
   localparam bit[AxiAw-1:0] ClustBaseAddr   = ClustBase - (ClustIdx << 22);
   localparam bit[AxiAw-1:0] L2BaseAddr      = 'h1C000000;
   localparam bit[AxiAw-1:0] L2Size          = 'h00100000;
+  localparam bit[AxiAw-1:0] UartBaseAddr    = 'h40000000;
+  localparam bit[AxiAw-1:0] UartSize        = 'h1000;
   localparam bit[AxiAw-1:0] BootAddr        = L2BaseAddr + 'h8080;
   localparam bit[AxiAw-1:0] ClustReturnInt  = ClustBase + ClustPeriphOffs + 'h100;
 
@@ -177,12 +179,12 @@ module pulp_cluster_tb;
   );
 
   mock_uart_axi #(
-   .AxiIw   ( AxiIwMst      ),
-   .AxiAw   ( AxiAw         ),
-   .AxiDw   ( AxiDw         ),
-   .AxiUw   ( AxiUw         ),
-   .N_CORES ( 8             ),
-   .BaseAddr( 32'h4000_0000 )
+   .AxiIw   ( AxiIwMst     ),
+   .AxiAw   ( AxiAw        ),
+   .AxiDw   ( AxiDw        ),
+   .AxiUw   ( AxiUw        ),
+   .N_CORES ( `NB_CORES    ),
+   .BaseAddr( UartBaseAddr )
   ) i_mock_uart (
      .clk_i  ( s_clk         ),
      .rst_ni ( s_rstn        ),
@@ -202,8 +204,8 @@ module pulp_cluster_tb;
   rule_t [NumRules-1:0] addr_map;
   assign addr_map[0] = '{ // UART
     idx:        0,
-    start_addr: 'h03002000,
-    end_addr:   'h03003000
+    start_addr: UartBaseAddr,
+    end_addr:   UartBaseAddr + UartSize
   };
   assign addr_map[1] = '{ // 512KiB L2SPM
     idx:        1,


### PR DESCRIPTION
This PR:
- Improve HMR parametrization to avoid warnings about width mismatches in HMR signals when only DMR is enabled. This warnings result in errors when synthesizing the design with Design Compiler.
- Add an assertion to verify that either DMR or TMR is enabled when HMR is present.
- Fix the mock UART AXI address map in the testbench to be aligned with the default Pulp Cluster configuration (it addresses #15 )

Regression locally executed.