### PR TITLE
iDMA clock gating

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -63,7 +63,7 @@ packages:
     dependencies:
     - common_cells
   cluster_peripherals:
-    revision: 1d34283e6958cea76ba2a05fe3581da58d8af7fe
+    revision: 6e55d0a74ff33ce9aac9fcd44ad702f323ace644
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/cluster_peripherals.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -63,10 +63,10 @@ packages:
     dependencies:
     - common_cells
   cluster_peripherals:
-    revision: e464eb9ddcc39e5a50009819601c4f213b1d4ba3
-    version: 2.2.0
+    revision: 1d34283e6958cea76ba2a05fe3581da58d8af7fe
+    version: null
     source:
-      Git: https://github.com/pulp-platform/cluster_peripherals.git
+      Git: https://github.com/FondazioneChipsIT/cluster_peripherals.git
     dependencies:
     - hci
   common_cells:

--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,7 @@ dependencies:
   obi:                    { git: "https://github.com/pulp-platform/obi.git", version: =0.1.7 }
   hier-icache:            { git: "https://github.com/FondazioneChipsIT/hier-icache.git", rev: 416c5cbc7b9b8724a40da6ac6d0b19a9c6b864bc } # gl/fix_define
   cluster_icache:         { git: "https://github.com/FondazioneChipsIT/cluster_icache.git", rev: 57ffb22066171d89974bdec240bad13f5efac9de } # gl/fix_define
-  cluster_peripherals:    { git: "https://github.com/pulp-platform/cluster_peripherals.git", version: =2.2.0 }
+  cluster_peripherals:    { git: "https://github.com/FondazioneChipsIT/cluster_peripherals.git", rev: "1d34283e6958cea76ba2a05fe3581da58d8af7fe" } # rg/idma_clock_gating
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: =0.39.8  }
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: =1.0.2 }
   common_cells:           { git: "https://github.com/FondazioneChipsIT/common_cells.git", rev: 286ffd49d9ed3409ceaef7c7fe98516e2611a1a9 } # gl/fix_define

--- a/Bender.yml
+++ b/Bender.yml
@@ -22,7 +22,7 @@ dependencies:
   obi:                    { git: "https://github.com/pulp-platform/obi.git", version: =0.1.7 }
   hier-icache:            { git: "https://github.com/FondazioneChipsIT/hier-icache.git", rev: 416c5cbc7b9b8724a40da6ac6d0b19a9c6b864bc } # gl/fix_define
   cluster_icache:         { git: "https://github.com/FondazioneChipsIT/cluster_icache.git", rev: 57ffb22066171d89974bdec240bad13f5efac9de } # gl/fix_define
-  cluster_peripherals:    { git: "https://github.com/FondazioneChipsIT/cluster_peripherals.git", rev: "1d34283e6958cea76ba2a05fe3581da58d8af7fe" } # rg/idma_clock_gating
+  cluster_peripherals:    { git: "https://github.com/FondazioneChipsIT/cluster_peripherals.git", rev: "6e55d0a74ff33ce9aac9fcd44ad702f323ace644" } # rg/idma_clock_gating
   axi:                    { git: "https://github.com/pulp-platform/axi.git", version: =0.39.8  }
   timer_unit:             { git: "https://github.com/pulp-platform/timer_unit.git", version: =1.0.2 }
   common_cells:           { git: "https://github.com/FondazioneChipsIT/common_cells.git", rev: 286ffd49d9ed3409ceaef7c7fe98516e2611a1a9 } # gl/fix_define

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/FondazioneChipsIT/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 55fdd057ec176bf4eb9a6fcceb5a0b976d01a65d # branch: rg/add_iDMA_cg_drivers
+PULP_RUNTIME_COMMIT ?= 9bd23d2b2b6b6c74fc26a3ab3402fbebc589dace # branch: chips-it
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@
@@ -99,7 +99,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/FondazioneChipsIT/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= f1e8e193b45eb56bcad3a76aea7e5a1438d104d3 # branch: rg/test_idma_clock_gating
+REGRESSION_TESTS_COMMIT ?= dd41d893ee371df7407ce2c0128d2d3a45c4ec71 # branch: chips-it
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/FondazioneChipsIT/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 83919f7c7b8c2dbab5533f5114b4f8bd633349fb # branch: remap_iDMA_registers
+PULP_RUNTIME_COMMIT ?= 55fdd057ec176bf4eb9a6fcceb5a0b976d01a65d # branch: rg/add_iDMA_cg_drivers
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@
@@ -99,7 +99,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/FondazioneChipsIT/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= c9fcb90 # branch: new_iDMA_tests
+REGRESSION_TESTS_COMMIT ?= f1e8e193b45eb56bcad3a76aea7e5a1438d104d3 # branch: rg/test_idma_clock_gating
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -102,7 +102,7 @@ module cluster_peripherals
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
   output logic [$clog2(NB_HWPES)-1:0] hwpe_sel_o,
-  output logic                        idma_cg_en_o,
+  output logic                        idma_en_o,
   output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   // Control ports
@@ -193,7 +193,7 @@ module cluster_peripherals
     .hwpe_sel_o     ( hwpe_sel_o                   ),
     .hci_ctrl_o     ( hci_ctrl_o                   ),
 
-    .idma_cg_en_o   ( idma_cg_en_o                 ),
+    .idma_en_o   ( idma_en_o                 ),
 
     .fregfile_disable_o ( fregfile_disable_o       ),
 

--- a/rtl/cluster_peripherals.sv
+++ b/rtl/cluster_peripherals.sv
@@ -102,6 +102,7 @@ module cluster_peripherals
   input logic [NB_CORES-1:0][3:0]     hwpe_events_i,
   output logic                        hwpe_en_o,
   output logic [$clog2(NB_HWPES)-1:0] hwpe_sel_o,
+  output logic                        idma_cg_en_o,
   output hci_package::hci_interconnect_ctrl_t hci_ctrl_o,
 
   // Control ports
@@ -191,6 +192,8 @@ module cluster_peripherals
     .hwpe_en_o      ( hwpe_en_o                    ),
     .hwpe_sel_o     ( hwpe_sel_o                   ),
     .hci_ctrl_o     ( hci_ctrl_o                   ),
+
+    .idma_cg_en_o   ( idma_cg_en_o                 ),
 
     .fregfile_disable_o ( fregfile_disable_o       ),
 

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -55,7 +55,7 @@ module dmac_wrap #(
   hci_core_intf.initiator        tcdm_master[0:3],
   output                         axi_req_t [NUM_BIDIR_STREAMS-1:0] ext_master_req_o,
   input                          axi_resp_t [NUM_BIDIR_STREAMS-1:0] ext_master_resp_i,
-  input  logic                   cluster_ctrl_cg_en,
+  input  logic                   idma_en_i,
   output logic [NB_CORES-1:0]    term_event_o,
   output logic [NB_CORES-1:0]    term_irq_o,
   output logic [NB_PE_PORTS-1:0] term_event_pe_o,
@@ -211,7 +211,7 @@ module dmac_wrap #(
       .axi_req_t (axi_req_t),
       .axi_resp_t(axi_resp_t)
     ) i_init_axi_rw_join (
-      .clk_i ( ctrl_clk_gated ),
+      .clk_i ( clk_gated ),
       .rst_ni,
       .slv_read_req_i  (dma_req[2*s+1]),
       .slv_read_resp_o (dma_rsp[2*s+1]),
@@ -262,60 +262,16 @@ module dmac_wrap #(
 
   logic [NumStreams-1:0][31:0] done_id, next_id;
 
-  // ------------------------------------------------------
-  // CLOCK GATING CONTROL LOGIC
-  // ------------------------------------------------------
-
-  /* 
-    Clock gating is performed on all the iDMA datapath except for:
-      iDMA_frontend:
-        Must be able to detect incoming transfer requests
-      iDMA_periph_to_reg:
-        Must be able to translate incoming transfer requests before the frontend
-  */
-
-logic keep_clock, clk_en;
-
-// Register to keep the clock active until event completion
-
-always_ff @(posedge clk_i, negedge rst_ni) begin
-  if (rst_ni == 1'b0) begin
-    keep_clock <= 1'b0;
-  end else if (busy_o == 1'b1) begin
-    keep_clock <= 1'b1;
-  end else if (|trans_complete) begin
-      keep_clock <= 1'b0;
-  end
-end
-
-// Clock gating for iDMA is controlled either internally:
-//     - frontend and periph_to_reg modules are kept clocked in order to detect incoming transfer requests
-// or externally:
-//     - the cluster_ctrl_cg_en signal comes directly from the cluster control unit and completely gates the iDMA wrap.
-
-assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
-
-  // // ----------------------------------------------------------------------------------------------------------
-  // // DATAPATH CLOCK GATING CELL --> This gates everything except for the frontend and the periph_to_reg modules
-  // // ----------------------------------------------------------------------------------------------------------
-
-  // cluster_clock_gating idma_datapath_ckgate (
-  //   .clk_i      ( clk_i       ),
-  //   .en_i       ( cluster_ctrl_cg_en      ),
-  //   .test_en_i  ( test_mode_i ),
-  //   .clk_o      ( clk_gated   )
-  // );
-
   // ----------------------------------------------------------------------------------------------------------
   // CONTROL CLOCK GATING CELL --> This clock gating cell handles the clock gating control signal coming from
   //                               the cluster control unit, completely disabling the clock in the idma wrapper
   // ----------------------------------------------------------------------------------------------------------
 
   cluster_clock_gating idma_ctrl_ckgate (
-    .clk_i      ( clk_i              ),
-    .en_i       ( cluster_ctrl_cg_en ),
-    .test_en_i  ( test_mode_i        ),
-    .clk_o      ( ctrl_clk_gated     )
+    .clk_i      ( clk_i       ),
+    .en_i       ( idma_en_i   ),
+    .test_en_i  ( test_mode_i ),
+    .clk_o      ( clk_gated   )
   );
 
 
@@ -332,7 +288,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       .req_t(dma_regs_req_t),
       .rsp_t(dma_regs_rsp_t)
     ) i_pe_translate (
-      .clk_i    ( ctrl_clk_gated   ),
+      .clk_i    ( clk_gated   ),
       .rst_ni,
       .req_i    (config_req[i]),
       .add_i    (config_add[i][RegAddrWidth-1:0]),
@@ -358,7 +314,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
     .reg_rsp_t     (dma_regs_rsp_t),
     .dma_req_t     (idma_nd_req_t)
   ) i_idma_reg32_3d (
-    .clk_i         ( ctrl_clk_gated  ),
+    .clk_i         ( clk_gated  ),
     .rst_ni,
     .dma_ctrl_req_i(dma_regs_req),
     .dma_ctrl_rsp_o(dma_regs_rsp),
@@ -395,7 +351,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
     idma_transfer_id_gen #(
       .IdWidth(ID_WIDTH)
     ) i_idma_transfer_id_gen (
-      .clk_i      ( ctrl_clk_gated ),
+      .clk_i      ( clk_gated ),
       .rst_ni,
       .issue_i    (fe_valid[s] & fe_ready[s]),
       .retire_i   (trans_complete[s]),
@@ -412,7 +368,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       .DEPTH(GLOBAL_QUEUE_DEPTH),
       .T    (idma_nd_req_t)
     ) i_3D_request_fifo (
-      .clk_i     ( ctrl_clk_gated ),
+      .clk_i     ( clk_gated ),
       .rst_ni,
       .flush_i   (1'b0),
       .testmode_i(test_mode_i),
@@ -435,7 +391,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       .idma_nd_req_t(idma_nd_req_t),
       .RepWidths    (RepWidths)
     ) i_idma_3D_midend (
-      .clk_i            ( ctrl_clk_gated       ),
+      .clk_i            ( clk_gated       ),
       .rst_ni,
       .nd_req_i         (twod_req_queue[s]),
       .nd_req_valid_i   (twod_queue_valid[s]),
@@ -526,7 +482,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .ErrorHandling       ( 1'b0              ),
         .Burst_len           ( IDMA_BURST_LENGTH )
       ) i_idma_backend_r_obi_rw_init_w_axi (
-        .clk_i              ( ctrl_clk_gated                               ),
+        .clk_i              ( clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -633,7 +589,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i  ( ctrl_clk_gated ),
+        .clk_i  ( clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -649,7 +605,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -754,7 +710,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .RejectZeroTransfers (1'b1),
         .ErrorHandling       (1'b0)
       ) i_idma_backend_r_axi_rw_init_rw_obi (
-        .clk_i              ( ctrl_clk_gated                               ),
+        .clk_i              ( clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -869,7 +825,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -884,7 +840,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -929,7 +885,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .NumMaxTrans         ( 2             ),
         .UseIdForRouting     ( 1'b0          )
       ) obi_read_mux_i (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .testmode_i     (test_mode_i),
         .sbr_ports_req_i({obi_reorg_req_from_dma[s], obi_read_req_from_dma[s]}),
@@ -949,7 +905,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .obi_r_chan_t(obi_r_chan_t),
         .Depth(1)
       ) obi_rready_converter_reorg_i (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .test_mode_i,
         .sbr_a_chan_i  ( obi_reorg_req_from_dma[s].a       ),
@@ -974,7 +930,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_read_i (
-      .clk_i ( ctrl_clk_gated ),
+      .clk_i ( clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_read_req_muxed[s].a        ),
@@ -999,7 +955,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_wr_i (
-      .clk_i ( ctrl_clk_gated ),
+      .clk_i ( clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_write_req_from_dma[s].a       ),
@@ -1047,7 +1003,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_write (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .req_i         ( obi_write_req_from_rrc[s].req                                                                     ),
         .gnt_o         ( obi_write_rsp_to_rrc[s].gnt                                                                       ),
@@ -1088,7 +1044,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_read (
-        .clk_i ( ctrl_clk_gated ),
+        .clk_i ( clk_gated ),
         .rst_ni,
         .req_i         ( obi_read_req_from_rrc[s].req                                                                        ),
         .gnt_o         ( obi_read_rsp_to_rrc[s].gnt                                                                          ),
@@ -1137,7 +1093,7 @@ assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
           .MaxTrans (32'd1),
           .FifoDepth(32'd1)
         ) i_mem_to_banks_reorg (
-          .clk_i ( ctrl_clk_gated ),
+          .clk_i ( clk_gated ),
           .rst_ni,
           .req_i         ( obi_reorg_req_from_rrc[s].req                                                                     ),
           .gnt_o         ( obi_reorg_rsp_to_rrc[s].gnt                                                                       ),

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -273,48 +273,31 @@ module dmac_wrap #(
         Must be able to translate incoming transfer requests before the frontend
   */
 
-  logic idma_clk_enable;
-  logic busy_high, release_busy_high;
+logic keep_clock, clk_en;
 
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (rst_ni === 1'b0) begin
-      idma_clk_enable <= 1'b0; // gated by default
-      release_busy_high <= 1'b0;
-    end else if (one_fe_valid == 1'b1) begin
-// Start clocking the iDMA when the first valid request arrives
-      idma_clk_enable <= 1'b1;
-      release_busy_high <= 1'b0;
-    end else if ((busy_o == 1'b0) && (busy_high == 1'b1)) begin
-// Detect the fall transition on busy_o and wait on the last event before enabling the clock gating
-      if (|trans_complete) begin
-        idma_clk_enable <= 1'b0;
-        release_busy_high <= 1'b1;
-      end
-    end
-  end
+// Register to keep the clock active until event completion
 
-// The following register stores the info that a rising transition on busy_o has occurred.
-  always_ff @(posedge clk_i, negedge rst_ni) begin
-    if (rst_ni === 1'b0) begin
-      busy_high <= 1'b0;
-    end else if (busy_o == 1'b1) begin
-      // Save the info that busy_o went high
-      busy_high <= 1'b1;
-    end else if (release_busy_high == 1'b1) begin
-      // Put busy_high to 0
-      busy_high <= 1'b0;
-    end
+always_ff @(posedge clk_i, negedge rst_ni) begin
+  if (rst_ni == 1'b0) begin
+    keep_clock <= 1'b0;
+  end else if (busy_o == 1'b1) begin
+    keep_clock <= 1'b1;
+  end else if (|trans_complete) begin
+      keep_clock <= 1'b0;
   end
+end
+
+assign clk_en = busy_o | one_fe_valid | keep_clock;
 
   // ------------------------------------------------------
   // CLOCK GATING CELL
   // ------------------------------------------------------
 
   cluster_clock_gating idma_ckgate (
-    .clk_i      ( clk_i           ),
-    .en_i       ( idma_clk_enable ),
-    .test_en_i  ( test_mode_i     ),
-    .clk_o      ( clk_gated       )
+    .clk_i      ( clk_i       ),
+    .en_i       ( clk_en      ),
+    .test_en_i  ( test_mode_i ),
+    .clk_o      ( clk_gated   )
   );
 
 

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -79,6 +79,8 @@ module dmac_wrap #(
   logic [NumRegs-1:0]                  config_r_opc;
   logic [NumRegs-1:0][PE_ID_WIDTH-1:0] config_r_id;
 
+  logic clk_gated;
+
   // tie-off pe control ports
   for (genvar i = 0; i < NB_CORES; i++) begin : gen_ctrl_registers
     assign config_add[i]         = ctrl_slave[i].add;
@@ -208,7 +210,7 @@ module dmac_wrap #(
       .axi_req_t (axi_req_t),
       .axi_resp_t(axi_resp_t)
     ) i_init_axi_rw_join (
-      .clk_i,
+      .clk_i ( clk_gated ),
       .rst_ni,
       .slv_read_req_i  (dma_req[2*s+1]),
       .slv_read_resp_o (dma_rsp[2*s+1]),
@@ -260,6 +262,63 @@ module dmac_wrap #(
   logic [NumStreams-1:0][31:0] done_id, next_id;
 
   // ------------------------------------------------------
+  // CLOCK GATING CONTROL LOGIC
+  // ------------------------------------------------------
+
+  /* 
+    Clock gating is performed on all the iDMA datapath except for:
+      iDMA_frontend:
+        Must be able to detect incoming transfer requests
+      iDMA_periph_to_reg:
+        Must be able to translate incoming transfer requests before the frontend
+  */
+
+  logic idma_clk_enable;
+  logic busy_high, release_busy_high;
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (rst_ni === 1'b0) begin
+      idma_clk_enable <= 1'b0; // gated by default
+      release_busy_high <= 1'b0;
+    end else if (one_fe_valid == 1'b1) begin
+// Start clocking the iDMA when the first valid request arrives
+      idma_clk_enable <= 1'b1;
+      release_busy_high <= 1'b0;
+    end else if ((busy_o == 1'b0) && (busy_high == 1'b1)) begin
+// Detect the fall transition on busy_o and wait on the last event before enabling the clock gating
+      if (|trans_complete) begin
+        idma_clk_enable <= 1'b0;
+        release_busy_high <= 1'b1;
+      end
+    end
+  end
+
+// The following register stores the info that a rising transition on busy_o has occurred.
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (rst_ni === 1'b0) begin
+      busy_high <= 1'b0;
+    end else if (busy_o == 1'b1) begin
+      // Save the info that busy_o went high
+      busy_high <= 1'b1;
+    end else if (release_busy_high == 1'b1) begin
+      // Put busy_high to 0
+      busy_high <= 1'b0;
+    end
+  end
+
+  // ------------------------------------------------------
+  // CLOCK GATING CELL
+  // ------------------------------------------------------
+
+  cluster_clock_gating idma_ckgate (
+    .clk_i      ( clk_i           ),
+    .en_i       ( idma_clk_enable ),
+    .test_en_i  ( test_mode_i     ),
+    .clk_o      ( clk_gated       )
+  );
+
+
+  // ------------------------------------------------------
   // FRONTEND
   // ------------------------------------------------------
 
@@ -272,7 +331,7 @@ module dmac_wrap #(
       .req_t(dma_regs_req_t),
       .rsp_t(dma_regs_rsp_t)
     ) i_pe_translate (
-      .clk_i,
+      .clk_i    ( clk_i   ),
       .rst_ni,
       .req_i    (config_req[i]),
       .add_i    (config_add[i][RegAddrWidth-1:0]),
@@ -298,7 +357,7 @@ module dmac_wrap #(
     .reg_rsp_t     (dma_regs_rsp_t),
     .dma_req_t     (idma_nd_req_t)
   ) i_idma_reg32_3d (
-    .clk_i,
+    .clk_i         ( clk_i  ),
     .rst_ni,
     .dma_ctrl_req_i(dma_regs_req),
     .dma_ctrl_rsp_o(dma_regs_rsp),
@@ -335,7 +394,7 @@ module dmac_wrap #(
     idma_transfer_id_gen #(
       .IdWidth(ID_WIDTH)
     ) i_idma_transfer_id_gen (
-      .clk_i,
+      .clk_i      ( clk_gated ),
       .rst_ni,
       .issue_i    (fe_valid[s] & fe_ready[s]),
       .retire_i   (trans_complete[s]),
@@ -352,7 +411,7 @@ module dmac_wrap #(
       .DEPTH(GLOBAL_QUEUE_DEPTH),
       .T    (idma_nd_req_t)
     ) i_3D_request_fifo (
-      .clk_i,
+      .clk_i     ( clk_gated ),
       .rst_ni,
       .flush_i   (1'b0),
       .testmode_i(test_mode_i),
@@ -375,7 +434,7 @@ module dmac_wrap #(
       .idma_nd_req_t(idma_nd_req_t),
       .RepWidths    (RepWidths)
     ) i_idma_3D_midend (
-      .clk_i,
+      .clk_i            ( clk_gated       ),
       .rst_ni,
       .nd_req_i         (twod_req_queue[s]),
       .nd_req_valid_i   (twod_queue_valid[s]),
@@ -466,7 +525,7 @@ module dmac_wrap #(
         .ErrorHandling       ( 1'b0              ),
         .Burst_len           ( IDMA_BURST_LENGTH )
       ) i_idma_backend_r_obi_rw_init_w_axi (
-        .clk_i              ( clk_i                                   ),
+        .clk_i              ( clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -573,7 +632,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i,
+        .clk_i  ( clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -589,7 +648,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -694,7 +753,7 @@ module dmac_wrap #(
         .RejectZeroTransfers (1'b1),
         .ErrorHandling       (1'b0)
       ) i_idma_backend_r_axi_rw_init_rw_obi (
-        .clk_i              ( clk_i                                   ),
+        .clk_i              ( clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -809,7 +868,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -824,7 +883,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -869,7 +928,7 @@ module dmac_wrap #(
         .NumMaxTrans         ( 2             ),
         .UseIdForRouting     ( 1'b0          )
       ) obi_read_mux_i (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .testmode_i     (test_mode_i),
         .sbr_ports_req_i({obi_reorg_req_from_dma[s], obi_read_req_from_dma[s]}),
@@ -889,7 +948,7 @@ module dmac_wrap #(
         .obi_r_chan_t(obi_r_chan_t),
         .Depth(1)
       ) obi_rready_converter_reorg_i (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .test_mode_i,
         .sbr_a_chan_i  ( obi_reorg_req_from_dma[s].a       ),
@@ -914,7 +973,7 @@ module dmac_wrap #(
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_read_i (
-      .clk_i,
+      .clk_i ( clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_read_req_muxed[s].a        ),
@@ -939,7 +998,7 @@ module dmac_wrap #(
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_wr_i (
-      .clk_i,
+      .clk_i ( clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_write_req_from_dma[s].a       ),
@@ -987,7 +1046,7 @@ module dmac_wrap #(
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_write (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .req_i         ( obi_write_req_from_rrc[s].req                                                                     ),
         .gnt_o         ( obi_write_rsp_to_rrc[s].gnt                                                                       ),
@@ -1028,7 +1087,7 @@ module dmac_wrap #(
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_read (
-        .clk_i,
+        .clk_i ( clk_gated ),
         .rst_ni,
         .req_i         ( obi_read_req_from_rrc[s].req                                                                        ),
         .gnt_o         ( obi_read_rsp_to_rrc[s].gnt                                                                          ),
@@ -1077,7 +1136,7 @@ module dmac_wrap #(
           .MaxTrans (32'd1),
           .FifoDepth(32'd1)
         ) i_mem_to_banks_reorg (
-          .clk_i,
+          .clk_i ( clk_gated ),
           .rst_ni,
           .req_i         ( obi_reorg_req_from_rrc[s].req                                                                     ),
           .gnt_o         ( obi_reorg_rsp_to_rrc[s].gnt                                                                       ),

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -277,6 +277,10 @@ module dmac_wrap #(
   logic keep_datapath_clocked, datapath_clk_en;
 
   // Register to keep the clock active until event completion
+  //    Once the transfer has started its execution (busy_o == 1'b1)
+  //    the datapath needs to be clocked until the completion event
+  //    has been received (|trans_complete). Then the datapath
+  //    can be gated again.
 
   always_ff @(posedge clk_i, negedge rst_ni) begin
     if (rst_ni == 1'b0) begin
@@ -293,17 +297,17 @@ module dmac_wrap #(
   // or externally:
   //     - the idma_en_i signal comes directly from the cluster control unit and completely gates the iDMA wrap.
 
-  assign datapath_clk_en = (busy_o | one_fe_valid | keep_datapath_clocked) & idma_en_i;
+  assign datapath_clk_en = (one_fe_valid | busy_o | (|trans_complete) | keep_datapath_clocked) & idma_en_i;
 
   // // ----------------------------------------------------------------------------------------------------------
   // // DATAPATH CLOCK GATING CELL --> This gates everything except for the frontend and the periph_to_reg modules
   // // ----------------------------------------------------------------------------------------------------------
 
   cluster_clock_gating idma_datapath_ckgate (
-    .clk_i      ( clk_i           ),
-    .en_i       ( datapath_clk_en ),
-    .test_en_i  ( test_mode_i     ),
-    .clk_o      ( datapath_clk_gated       )
+    .clk_i      ( clk_i              ),
+    .en_i       ( datapath_clk_en    ),
+    .test_en_i  ( test_mode_i        ),
+    .clk_o      ( datapath_clk_gated )
   );
 
   // ----------------------------------------------------------------------------------------------------------
@@ -312,10 +316,10 @@ module dmac_wrap #(
   // ----------------------------------------------------------------------------------------------------------
 
   cluster_clock_gating idma_ctrl_ckgate (
-    .clk_i      ( clk_i       ),
-    .en_i       ( idma_en_i   ),
-    .test_en_i  ( test_mode_i ),
-    .clk_o      ( ctrl_clk_gated   )
+    .clk_i      ( clk_i          ),
+    .en_i       ( idma_en_i      ),
+    .test_en_i  ( test_mode_i    ),
+    .clk_o      ( ctrl_clk_gated )
   );
 
 

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -80,7 +80,7 @@ module dmac_wrap #(
   logic [NumRegs-1:0]                  config_r_opc;
   logic [NumRegs-1:0][PE_ID_WIDTH-1:0] config_r_id;
 
-  logic clk_gated;
+  logic ctrl_clk_gated, datapath_clk_gated;
 
   // tie-off pe control ports
   for (genvar i = 0; i < NB_CORES; i++) begin : gen_ctrl_registers
@@ -211,7 +211,7 @@ module dmac_wrap #(
       .axi_req_t (axi_req_t),
       .axi_resp_t(axi_resp_t)
     ) i_init_axi_rw_join (
-      .clk_i ( clk_gated ),
+      .clk_i ( datapath_clk_gated ),
       .rst_ni,
       .slv_read_req_i  (dma_req[2*s+1]),
       .slv_read_resp_o (dma_rsp[2*s+1]),
@@ -262,6 +262,50 @@ module dmac_wrap #(
 
   logic [NumStreams-1:0][31:0] done_id, next_id;
 
+  // ------------------------------------------------------
+  // CLOCK GATING CONTROL LOGIC
+  // ------------------------------------------------------
+
+  /* 
+    Clock gating is performed on all the iDMA datapath except for:
+      iDMA_frontend:
+        Must be able to detect incoming transfer requests
+      iDMA_periph_to_reg:
+        Must be able to translate incoming transfer requests before the frontend
+  */
+
+  logic keep_datapath_clocked, datapath_clk_en;
+
+  // Register to keep the clock active until event completion
+
+  always_ff @(posedge clk_i, negedge rst_ni) begin
+    if (rst_ni == 1'b0) begin
+      keep_datapath_clocked <= 1'b0;
+    end else if (busy_o == 1'b1) begin
+      keep_datapath_clocked <= 1'b1;
+    end else if (|trans_complete) begin
+      keep_datapath_clocked <= 1'b0;
+    end
+  end
+
+  // Clock gating for iDMA is controlled either internally:
+  //     - frontend and periph_to_reg modules are kept clocked in order to detect incoming transfer requests
+  // or externally:
+  //     - the idma_en_i signal comes directly from the cluster control unit and completely gates the iDMA wrap.
+
+  assign datapath_clk_en = (busy_o | one_fe_valid | keep_datapath_clocked) & idma_en_i;
+
+  // // ----------------------------------------------------------------------------------------------------------
+  // // DATAPATH CLOCK GATING CELL --> This gates everything except for the frontend and the periph_to_reg modules
+  // // ----------------------------------------------------------------------------------------------------------
+
+  cluster_clock_gating idma_datapath_ckgate (
+    .clk_i      ( clk_i           ),
+    .en_i       ( datapath_clk_en ),
+    .test_en_i  ( test_mode_i     ),
+    .clk_o      ( datapath_clk_gated       )
+  );
+
   // ----------------------------------------------------------------------------------------------------------
   // CONTROL CLOCK GATING CELL --> This clock gating cell handles the clock gating control signal coming from
   //                               the cluster control unit, completely disabling the clock in the idma wrapper
@@ -271,7 +315,7 @@ module dmac_wrap #(
     .clk_i      ( clk_i       ),
     .en_i       ( idma_en_i   ),
     .test_en_i  ( test_mode_i ),
-    .clk_o      ( clk_gated   )
+    .clk_o      ( ctrl_clk_gated   )
   );
 
 
@@ -288,7 +332,7 @@ module dmac_wrap #(
       .req_t(dma_regs_req_t),
       .rsp_t(dma_regs_rsp_t)
     ) i_pe_translate (
-      .clk_i    ( clk_gated   ),
+      .clk_i    ( ctrl_clk_gated   ),
       .rst_ni,
       .req_i    (config_req[i]),
       .add_i    (config_add[i][RegAddrWidth-1:0]),
@@ -314,7 +358,7 @@ module dmac_wrap #(
     .reg_rsp_t     (dma_regs_rsp_t),
     .dma_req_t     (idma_nd_req_t)
   ) i_idma_reg32_3d (
-    .clk_i         ( clk_gated  ),
+    .clk_i         ( ctrl_clk_gated  ),
     .rst_ni,
     .dma_ctrl_req_i(dma_regs_req),
     .dma_ctrl_rsp_o(dma_regs_rsp),
@@ -351,7 +395,7 @@ module dmac_wrap #(
     idma_transfer_id_gen #(
       .IdWidth(ID_WIDTH)
     ) i_idma_transfer_id_gen (
-      .clk_i      ( clk_gated ),
+      .clk_i      ( datapath_clk_gated ),
       .rst_ni,
       .issue_i    (fe_valid[s] & fe_ready[s]),
       .retire_i   (trans_complete[s]),
@@ -368,7 +412,7 @@ module dmac_wrap #(
       .DEPTH(GLOBAL_QUEUE_DEPTH),
       .T    (idma_nd_req_t)
     ) i_3D_request_fifo (
-      .clk_i     ( clk_gated ),
+      .clk_i     ( datapath_clk_gated ),
       .rst_ni,
       .flush_i   (1'b0),
       .testmode_i(test_mode_i),
@@ -391,7 +435,7 @@ module dmac_wrap #(
       .idma_nd_req_t(idma_nd_req_t),
       .RepWidths    (RepWidths)
     ) i_idma_3D_midend (
-      .clk_i            ( clk_gated       ),
+      .clk_i            ( datapath_clk_gated       ),
       .rst_ni,
       .nd_req_i         (twod_req_queue[s]),
       .nd_req_valid_i   (twod_queue_valid[s]),
@@ -482,7 +526,7 @@ module dmac_wrap #(
         .ErrorHandling       ( 1'b0              ),
         .Burst_len           ( IDMA_BURST_LENGTH )
       ) i_idma_backend_r_obi_rw_init_w_axi (
-        .clk_i              ( clk_gated                               ),
+        .clk_i              ( datapath_clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -589,7 +633,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i  ( clk_gated ),
+        .clk_i  ( datapath_clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -605,7 +649,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -710,7 +754,7 @@ module dmac_wrap #(
         .RejectZeroTransfers (1'b1),
         .ErrorHandling       (1'b0)
       ) i_idma_backend_r_axi_rw_init_rw_obi (
-        .clk_i              ( clk_gated                               ),
+        .clk_i              ( datapath_clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -825,7 +869,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -840,7 +884,7 @@ module dmac_wrap #(
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -885,7 +929,7 @@ module dmac_wrap #(
         .NumMaxTrans         ( 2             ),
         .UseIdForRouting     ( 1'b0          )
       ) obi_read_mux_i (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .testmode_i     (test_mode_i),
         .sbr_ports_req_i({obi_reorg_req_from_dma[s], obi_read_req_from_dma[s]}),
@@ -905,7 +949,7 @@ module dmac_wrap #(
         .obi_r_chan_t(obi_r_chan_t),
         .Depth(1)
       ) obi_rready_converter_reorg_i (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .test_mode_i,
         .sbr_a_chan_i  ( obi_reorg_req_from_dma[s].a       ),
@@ -930,7 +974,7 @@ module dmac_wrap #(
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_read_i (
-      .clk_i ( clk_gated ),
+      .clk_i ( datapath_clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_read_req_muxed[s].a        ),
@@ -955,7 +999,7 @@ module dmac_wrap #(
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_wr_i (
-      .clk_i ( clk_gated ),
+      .clk_i ( datapath_clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_write_req_from_dma[s].a       ),
@@ -1003,7 +1047,7 @@ module dmac_wrap #(
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_write (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .req_i         ( obi_write_req_from_rrc[s].req                                                                     ),
         .gnt_o         ( obi_write_rsp_to_rrc[s].gnt                                                                       ),
@@ -1044,7 +1088,7 @@ module dmac_wrap #(
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_read (
-        .clk_i ( clk_gated ),
+        .clk_i ( datapath_clk_gated ),
         .rst_ni,
         .req_i         ( obi_read_req_from_rrc[s].req                                                                        ),
         .gnt_o         ( obi_read_rsp_to_rrc[s].gnt                                                                          ),
@@ -1093,7 +1137,7 @@ module dmac_wrap #(
           .MaxTrans (32'd1),
           .FifoDepth(32'd1)
         ) i_mem_to_banks_reorg (
-          .clk_i ( clk_gated ),
+          .clk_i ( datapath_clk_gated ),
           .rst_ni,
           .req_i         ( obi_reorg_req_from_rrc[s].req                                                                     ),
           .gnt_o         ( obi_reorg_rsp_to_rrc[s].gnt                                                                       ),

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -55,7 +55,6 @@ module dmac_wrap #(
   hci_core_intf.initiator        tcdm_master[0:3],
   output                         axi_req_t [NUM_BIDIR_STREAMS-1:0] ext_master_req_o,
   input                          axi_resp_t [NUM_BIDIR_STREAMS-1:0] ext_master_resp_i,
-  input  logic                   idma_en_i,
   output logic [NB_CORES-1:0]    term_event_o,
   output logic [NB_CORES-1:0]    term_irq_o,
   output logic [NB_PE_PORTS-1:0] term_event_pe_o,
@@ -80,7 +79,7 @@ module dmac_wrap #(
   logic [NumRegs-1:0]                  config_r_opc;
   logic [NumRegs-1:0][PE_ID_WIDTH-1:0] config_r_id;
 
-  logic ctrl_clk_gated, datapath_clk_gated;
+  logic datapath_clk_gated;
 
   // tie-off pe control ports
   for (genvar i = 0; i < NB_CORES; i++) begin : gen_ctrl_registers
@@ -266,13 +265,11 @@ module dmac_wrap #(
   // CLOCK GATING CONTROL LOGIC
   // ------------------------------------------------------
 
-  /* 
-    Clock gating is performed on all the iDMA datapath except for:
-      iDMA_frontend:
-        Must be able to detect incoming transfer requests
-      iDMA_periph_to_reg:
-        Must be able to translate incoming transfer requests before the frontend
-  */
+  // A first level of clock gating is performed at cluster level:
+  //    - the clock for the whole iDMA wrapper can be controlled via sw through the cluster control unit.
+  //      By disabling it, iDMA becomes unresponsive to incoming requests.
+  // Here, another clock gating level is applied:
+  //    - completely hw-controlled, this clock gating cell controls the datapath clock, disabling it when not needed.
 
   logic keep_datapath_clocked, datapath_clk_en;
 
@@ -292,12 +289,7 @@ module dmac_wrap #(
     end
   end
 
-  // Clock gating for iDMA is controlled either internally:
-  //     - frontend and periph_to_reg modules are kept clocked in order to detect incoming transfer requests
-  // or externally:
-  //     - the idma_en_i signal comes directly from the cluster control unit and completely gates the iDMA wrap.
-
-  assign datapath_clk_en = (one_fe_valid | busy_o | (|trans_complete) | keep_datapath_clocked) & idma_en_i;
+  assign datapath_clk_en = (one_fe_valid | (|trans_complete) | keep_datapath_clocked);
 
   // // ----------------------------------------------------------------------------------------------------------
   // // DATAPATH CLOCK GATING CELL --> This gates everything except for the frontend and the periph_to_reg modules
@@ -309,19 +301,6 @@ module dmac_wrap #(
     .test_en_i  ( test_mode_i        ),
     .clk_o      ( datapath_clk_gated )
   );
-
-  // ----------------------------------------------------------------------------------------------------------
-  // CONTROL CLOCK GATING CELL --> This clock gating cell handles the clock gating control signal coming from
-  //                               the cluster control unit, completely disabling the clock in the idma wrapper
-  // ----------------------------------------------------------------------------------------------------------
-
-  cluster_clock_gating idma_ctrl_ckgate (
-    .clk_i      ( clk_i          ),
-    .en_i       ( idma_en_i      ),
-    .test_en_i  ( test_mode_i    ),
-    .clk_o      ( ctrl_clk_gated )
-  );
-
 
   // ------------------------------------------------------
   // FRONTEND
@@ -336,7 +315,7 @@ module dmac_wrap #(
       .req_t(dma_regs_req_t),
       .rsp_t(dma_regs_rsp_t)
     ) i_pe_translate (
-      .clk_i    ( ctrl_clk_gated   ),
+      .clk_i    ( clk_i ),
       .rst_ni,
       .req_i    (config_req[i]),
       .add_i    (config_add[i][RegAddrWidth-1:0]),
@@ -362,7 +341,7 @@ module dmac_wrap #(
     .reg_rsp_t     (dma_regs_rsp_t),
     .dma_req_t     (idma_nd_req_t)
   ) i_idma_reg32_3d (
-    .clk_i         ( ctrl_clk_gated  ),
+    .clk_i         ( clk_i ),
     .rst_ni,
     .dma_ctrl_req_i(dma_regs_req),
     .dma_ctrl_rsp_o(dma_regs_rsp),

--- a/rtl/idma_wrap.sv
+++ b/rtl/idma_wrap.sv
@@ -55,6 +55,7 @@ module dmac_wrap #(
   hci_core_intf.initiator        tcdm_master[0:3],
   output                         axi_req_t [NUM_BIDIR_STREAMS-1:0] ext_master_req_o,
   input                          axi_resp_t [NUM_BIDIR_STREAMS-1:0] ext_master_resp_i,
+  input  logic                   cluster_ctrl_cg_en,
   output logic [NB_CORES-1:0]    term_event_o,
   output logic [NB_CORES-1:0]    term_irq_o,
   output logic [NB_PE_PORTS-1:0] term_event_pe_o,
@@ -210,7 +211,7 @@ module dmac_wrap #(
       .axi_req_t (axi_req_t),
       .axi_resp_t(axi_resp_t)
     ) i_init_axi_rw_join (
-      .clk_i ( clk_gated ),
+      .clk_i ( ctrl_clk_gated ),
       .rst_ni,
       .slv_read_req_i  (dma_req[2*s+1]),
       .slv_read_resp_o (dma_rsp[2*s+1]),
@@ -287,17 +288,34 @@ always_ff @(posedge clk_i, negedge rst_ni) begin
   end
 end
 
-assign clk_en = busy_o | one_fe_valid | keep_clock;
+// Clock gating for iDMA is controlled either internally:
+//     - frontend and periph_to_reg modules are kept clocked in order to detect incoming transfer requests
+// or externally:
+//     - the cluster_ctrl_cg_en signal comes directly from the cluster control unit and completely gates the iDMA wrap.
 
-  // ------------------------------------------------------
-  // CLOCK GATING CELL
-  // ------------------------------------------------------
+assign clk_en = (busy_o | one_fe_valid | keep_clock) & cluster_ctrl_cg_en;
 
-  cluster_clock_gating idma_ckgate (
-    .clk_i      ( clk_i       ),
-    .en_i       ( clk_en      ),
-    .test_en_i  ( test_mode_i ),
-    .clk_o      ( clk_gated   )
+  // // ----------------------------------------------------------------------------------------------------------
+  // // DATAPATH CLOCK GATING CELL --> This gates everything except for the frontend and the periph_to_reg modules
+  // // ----------------------------------------------------------------------------------------------------------
+
+  // cluster_clock_gating idma_datapath_ckgate (
+  //   .clk_i      ( clk_i       ),
+  //   .en_i       ( cluster_ctrl_cg_en      ),
+  //   .test_en_i  ( test_mode_i ),
+  //   .clk_o      ( clk_gated   )
+  // );
+
+  // ----------------------------------------------------------------------------------------------------------
+  // CONTROL CLOCK GATING CELL --> This clock gating cell handles the clock gating control signal coming from
+  //                               the cluster control unit, completely disabling the clock in the idma wrapper
+  // ----------------------------------------------------------------------------------------------------------
+
+  cluster_clock_gating idma_ctrl_ckgate (
+    .clk_i      ( clk_i              ),
+    .en_i       ( cluster_ctrl_cg_en ),
+    .test_en_i  ( test_mode_i        ),
+    .clk_o      ( ctrl_clk_gated     )
   );
 
 
@@ -314,7 +332,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       .req_t(dma_regs_req_t),
       .rsp_t(dma_regs_rsp_t)
     ) i_pe_translate (
-      .clk_i    ( clk_i   ),
+      .clk_i    ( ctrl_clk_gated   ),
       .rst_ni,
       .req_i    (config_req[i]),
       .add_i    (config_add[i][RegAddrWidth-1:0]),
@@ -340,7 +358,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
     .reg_rsp_t     (dma_regs_rsp_t),
     .dma_req_t     (idma_nd_req_t)
   ) i_idma_reg32_3d (
-    .clk_i         ( clk_i  ),
+    .clk_i         ( ctrl_clk_gated  ),
     .rst_ni,
     .dma_ctrl_req_i(dma_regs_req),
     .dma_ctrl_rsp_o(dma_regs_rsp),
@@ -377,7 +395,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
     idma_transfer_id_gen #(
       .IdWidth(ID_WIDTH)
     ) i_idma_transfer_id_gen (
-      .clk_i      ( clk_gated ),
+      .clk_i      ( ctrl_clk_gated ),
       .rst_ni,
       .issue_i    (fe_valid[s] & fe_ready[s]),
       .retire_i   (trans_complete[s]),
@@ -394,7 +412,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       .DEPTH(GLOBAL_QUEUE_DEPTH),
       .T    (idma_nd_req_t)
     ) i_3D_request_fifo (
-      .clk_i     ( clk_gated ),
+      .clk_i     ( ctrl_clk_gated ),
       .rst_ni,
       .flush_i   (1'b0),
       .testmode_i(test_mode_i),
@@ -417,7 +435,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       .idma_nd_req_t(idma_nd_req_t),
       .RepWidths    (RepWidths)
     ) i_idma_3D_midend (
-      .clk_i            ( clk_gated       ),
+      .clk_i            ( ctrl_clk_gated       ),
       .rst_ni,
       .nd_req_i         (twod_req_queue[s]),
       .nd_req_valid_i   (twod_queue_valid[s]),
@@ -508,7 +526,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .ErrorHandling       ( 1'b0              ),
         .Burst_len           ( IDMA_BURST_LENGTH )
       ) i_idma_backend_r_obi_rw_init_w_axi (
-        .clk_i              ( clk_gated                               ),
+        .clk_i              ( ctrl_clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -615,7 +633,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i  ( clk_gated ),
+        .clk_i  ( ctrl_clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -631,7 +649,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -736,7 +754,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .RejectZeroTransfers (1'b1),
         .ErrorHandling       (1'b0)
       ) i_idma_backend_r_axi_rw_init_rw_obi (
-        .clk_i              ( clk_gated                               ),
+        .clk_i              ( ctrl_clk_gated                               ),
         .rst_ni             ( rst_ni                                  ),
         .test_i             ( test_mode_i                             ),
         .req_valid_i        ( be_valid[s]                             ),
@@ -851,7 +869,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       spill_register #(
         .T(logic)
       ) i_init_read_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .valid_i(init_read_req.req_valid),
         .ready_o(init_read_rsp.req_ready),
@@ -866,7 +884,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       spill_register #(
         .T(logic)
       ) i_init_write_rsp_reflect (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .valid_i(init_write_req.req_valid),
         .ready_o(init_write_rsp.req_ready),
@@ -911,7 +929,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .NumMaxTrans         ( 2             ),
         .UseIdForRouting     ( 1'b0          )
       ) obi_read_mux_i (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .testmode_i     (test_mode_i),
         .sbr_ports_req_i({obi_reorg_req_from_dma[s], obi_read_req_from_dma[s]}),
@@ -931,7 +949,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .obi_r_chan_t(obi_r_chan_t),
         .Depth(1)
       ) obi_rready_converter_reorg_i (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .test_mode_i,
         .sbr_a_chan_i  ( obi_reorg_req_from_dma[s].a       ),
@@ -956,7 +974,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_read_i (
-      .clk_i ( clk_gated ),
+      .clk_i ( ctrl_clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_read_req_muxed[s].a        ),
@@ -981,7 +999,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
       .obi_r_chan_t(obi_r_chan_t),
       .Depth(1)
     ) obi_rready_converter_wr_i (
-      .clk_i ( clk_gated ),
+      .clk_i ( ctrl_clk_gated ),
       .rst_ni,
       .test_mode_i,
       .sbr_a_chan_i  ( obi_write_req_from_dma[s].a       ),
@@ -1029,7 +1047,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_write (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .req_i         ( obi_write_req_from_rrc[s].req                                                                     ),
         .gnt_o         ( obi_write_rsp_to_rrc[s].gnt                                                                       ),
@@ -1070,7 +1088,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
         .MaxTrans (32'd1),
         .FifoDepth(32'd1)
       ) i_mem_to_banks_read (
-        .clk_i ( clk_gated ),
+        .clk_i ( ctrl_clk_gated ),
         .rst_ni,
         .req_i         ( obi_read_req_from_rrc[s].req                                                                        ),
         .gnt_o         ( obi_read_rsp_to_rrc[s].gnt                                                                          ),
@@ -1119,7 +1137,7 @@ assign clk_en = busy_o | one_fe_valid | keep_clock;
           .MaxTrans (32'd1),
           .FifoDepth(32'd1)
         ) i_mem_to_banks_reorg (
-          .clk_i ( clk_gated ),
+          .clk_i ( ctrl_clk_gated ),
           .rst_ni,
           .req_i         ( obi_reorg_req_from_rrc[s].req                                                                     ),
           .gnt_o         ( obi_reorg_rsp_to_rrc[s].gnt                                                                       ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -228,6 +228,8 @@ logic [Cfg.NumCores-1:0]                s_dbg_irq;
 logic                                   s_hwpe_en;
 logic [$clog2(MAX_NUM_HWPES)-1:0]       s_hwpe_sel;
 
+logic                     s_idma_cg_en;
+
 logic                     fetch_en_synch;
 logic                     en_sa_boot_synch;
 logic                     axi_isolate_synch;
@@ -740,6 +742,9 @@ dmac_wrap #(
   .ext_master_req_o   ( s_dma_ext_bus_req                ),
   .ext_master_resp_i  ( s_dma_ext_bus_resp               ),
 
+`ifdef TARGET_IDMA
+  .cluster_ctrl_cg_en ( s_idma_cg_en                     ),
+`endif
   .term_event_o       ( s_dma_event                      ),
   .term_irq_o         ( s_dma_irq                        ),
   .term_event_pe_o    ( {s_dma_fc_event, s_dma_cl_event} ),
@@ -826,6 +831,7 @@ cluster_peripherals #(
   .hwpe_events_i            ( s_hwpe_remap_evt                  ),
   .hwpe_en_o                ( s_hwpe_en                         ),
   .hwpe_sel_o               ( s_hwpe_sel                        ),
+  .idma_cg_en_o             ( s_idma_cg_en                      ),
   .hci_ctrl_o               ( s_hci_ctrl                        ),
   .enable_l1_l15_prefetch_o (  s_enable_l1_l15_prefetch         ),
   .flush_valid_o            ( s_icache_flush_valid              ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -704,6 +704,26 @@ cluster_interconnect_wrap #(
 );
 
 //***************************************************
+//****************iDMA Clock Gating******************
+//***************************************************
+//*****************************************************
+// CONTROL CLOCK GATING CELL --> This clock gating cell
+// handles the clock gating control signal coming from
+// the cluster control unit, completely disabling the
+// clock in the idma wrapper
+//*****************************************************
+
+`ifdef TARGET_IDMA
+logic idma_clk_gated;
+cluster_clock_gating idma_ctrl_ckgate (
+    .clk_i      ( clk_i          ),
+    .en_i       ( s_idma_en      ),
+    .test_en_i  ( test_mode_i    ),
+    .clk_o      ( idma_clk_gated )
+  );
+`endif
+
+//***************************************************
 //*********************DMAC WRAP*********************
 //***************************************************
 dmac_wrap #(
@@ -732,7 +752,11 @@ dmac_wrap #(
   .IDMA_BURST_LENGTH  ( Cfg.DmaBurstLength          )
 `endif
 ) dmac_wrap_i     (
+`ifdef TARGET_IDMA
+  .clk_i              ( idma_clk_gated                   ),
+`else
   .clk_i              ( clk_i                            ),
+`endif
   .rst_ni             ( rst_ni                           ),
   .test_mode_i        ( test_mode_i                      ),
   .pe_ctrl_slave      ( s_periph_dma_bus[1:0]            ),
@@ -742,9 +766,6 @@ dmac_wrap #(
   .ext_master_req_o   ( s_dma_ext_bus_req                ),
   .ext_master_resp_i  ( s_dma_ext_bus_resp               ),
 
-`ifdef TARGET_IDMA
-  .idma_en_i          ( s_idma_en                     ),
-`endif
   .term_event_o       ( s_dma_event                      ),
   .term_irq_o         ( s_dma_irq                        ),
   .term_event_pe_o    ( {s_dma_fc_event, s_dma_cl_event} ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -228,7 +228,7 @@ logic [Cfg.NumCores-1:0]                s_dbg_irq;
 logic                                   s_hwpe_en;
 logic [$clog2(MAX_NUM_HWPES)-1:0]       s_hwpe_sel;
 
-logic                     s_idma_cg_en;
+logic                     s_idma_en;
 
 logic                     fetch_en_synch;
 logic                     en_sa_boot_synch;
@@ -743,7 +743,7 @@ dmac_wrap #(
   .ext_master_resp_i  ( s_dma_ext_bus_resp               ),
 
 `ifdef TARGET_IDMA
-  .cluster_ctrl_cg_en ( s_idma_cg_en                     ),
+  .idma_en_i          ( s_idma_en                     ),
 `endif
   .term_event_o       ( s_dma_event                      ),
   .term_irq_o         ( s_dma_irq                        ),
@@ -831,7 +831,7 @@ cluster_peripherals #(
   .hwpe_events_i            ( s_hwpe_remap_evt                  ),
   .hwpe_en_o                ( s_hwpe_en                         ),
   .hwpe_sel_o               ( s_hwpe_sel                        ),
-  .idma_cg_en_o             ( s_idma_cg_en                      ),
+  .idma_en_o                ( s_idma_en                         ),
   .hci_ctrl_o               ( s_hci_ctrl                        ),
   .enable_l1_l15_prefetch_o (  s_enable_l1_l15_prefetch         ),
   .flush_valid_o            ( s_icache_flush_valid              ),


### PR DESCRIPTION
Adding clock gating capabilities to iDMA:

- _sw-controlled clock gating_: the clock for the whole iDMA wrapper can be disabled by programming the cluster control unit 
- _hw-controlled clock gating_: the clock for the iDMA datapath is entirely automatic and controlled in the dmac_wrap module