### PR TITLE
[HMR] Add timing diversity to DMR-configured cluster

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -248,7 +248,7 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: 70b5b78974366c7b1d6f25b21af1f69474d02a9e
+    revision: 957a149f23d0536a96544ea34ce09d9ad1716fba
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/redundancy_cells.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -248,7 +248,7 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: cb3d8468c564687c1f8f2516b90bd4af05bd052d
+    revision: 3e8889ef2e0debe382b98387e580fd852c4b0ccd
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/redundancy_cells.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -248,7 +248,7 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: 56034fe5130d321d4b91d65544ae2ac83343217d
+    revision: 70b5b78974366c7b1d6f25b21af1f69474d02a9e
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/redundancy_cells.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -248,7 +248,7 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: 3e8889ef2e0debe382b98387e580fd852c4b0ccd
+    revision: edaf9845738e5d00eb754f4dd41afb65cbf7ea7e
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/redundancy_cells.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -248,7 +248,7 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: 957a149f23d0536a96544ea34ce09d9ad1716fba
+    revision: cb3d8468c564687c1f8f2516b90bd4af05bd052d
     version: null
     source:
       Git: https://github.com/FondazioneChipsIT/redundancy_cells.git

--- a/Bender.lock
+++ b/Bender.lock
@@ -248,10 +248,10 @@ packages:
     - register_interface
     - tech_cells_generic
   redundancy_cells:
-    revision: 6ba6f415a9024decedabaf3f2b45263ff546dabd
+    revision: 56034fe5130d321d4b91d65544ae2ac83343217d
     version: null
     source:
-      Git: https://github.com/pulp-platform/redundancy_cells.git
+      Git: https://github.com/FondazioneChipsIT/redundancy_cells.git
     dependencies:
     - common_cells
     - common_verification

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 957a149f23d0536a96544ea34ce09d9ad1716fba } # rg/hmr_timing_div_v2
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: cb3d8468c564687c1f8f2516b90bd4af05bd052d } # rg/hmr_timing_div_v2
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 3e8889ef2e0debe382b98387e580fd852c4b0ccd } # yt/timing-diversity
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: edaf9845738e5d00eb754f4dd41afb65cbf7ea7e } # yt/timing-diversity
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: cb3d8468c564687c1f8f2516b90bd4af05bd052d } # rg/hmr_timing_div_v2
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 3e8889ef2e0debe382b98387e580fd852c4b0ccd } # yt/timing-diversity
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/pulp-platform/redundancy_cells.git", rev: 6ba6f41 } # yt/redmule-v2
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 56034fe5130d321d4b91d65544ae2ac83343217d } # rg/hmr_timing_div_v2
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 70b5b78974366c7b1d6f25b21af1f69474d02a9e } # rg/hmr_timing_div_v2
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 957a149f23d0536a96544ea34ce09d9ad1716fba } # rg/hmr_timing_div_v2
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Bender.yml
+++ b/Bender.yml
@@ -33,7 +33,7 @@ dependencies:
   scm:                    { git: "https://github.com/pulp-platform/scm.git", version: =1.2.0 }
   hci:                    { git: "https://github.com/FondazioneChipsIT/hci.git", rev: 3e63936991569d0b1e315d6914478937b37bb338 }
   register_interface:     { git: "https://github.com/pulp-platform/register_interface.git", version: =0.4.7  }
-  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 56034fe5130d321d4b91d65544ae2ac83343217d } # rg/hmr_timing_div_v2
+  redundancy_cells:       { git: "https://github.com/FondazioneChipsIT/redundancy_cells.git", rev: 70b5b78974366c7b1d6f25b21af1f69474d02a9e } # rg/hmr_timing_div_v2
   redmule:                { git: "https://github.com/pulp-platform/redmule.git", version: =2.0.4 }
   neureka:                { git: "https://github.com/pulp-platform/neureka.git", rev: f4e131c } # branch: lg/astral-v1.1
   softex:                 { git: "https://github.com/FondazioneChipsIT/softex.git", rev: a622550d91dd55bf30bc359e10b2c70cae3042d6 } # gl/fix_pkg_import

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/FondazioneChipsIT/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 9bd23d2b2b6b6c74fc26a3ab3402fbebc589dace # branch: chips-it
+PULP_RUNTIME_COMMIT ?= 2b71eaa83e98e4c169a87bf42e837e28a2c45abe # branch: rg/hmr_no_rapid_recovery
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ sw-clean:
 
 ## Clone pulp-runtime as SW stack
 PULP_RUNTIME_REMOTE ?= https://github.com/FondazioneChipsIT/pulp-runtime.git
-PULP_RUNTIME_COMMIT ?= 2b71eaa83e98e4c169a87bf42e837e28a2c45abe # branch: rg/hmr_no_rapid_recovery
+PULP_RUNTIME_COMMIT ?= 9fcde54f7fcedea9267bfd86bf7442a11c16eebb # branch: rg/hmr_no_rapid_recovery
 
 pulp-runtime:
 	git clone $(PULP_RUNTIME_REMOTE) $@
@@ -98,7 +98,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/FondazioneChipsIT/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= dd41d893ee371df7407ce2c0128d2d3a45c4ec71 # branch: chips-it
+REGRESSION_TESTS_COMMIT ?= c9673899d76f1e98c358af952d89f506976844d2 # branch: rg/timing_div_hmr_test
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@

--- a/packages/pulp_cluster_package.sv
+++ b/packages/pulp_cluster_package.sv
@@ -100,6 +100,10 @@ package pulp_cluster_package;
     bit HMRSeparateAxiBus;
     // Number of separate voters/checkers for individual buses
     bit HMRNumBusVoters;
+    // Enable Timing Diversity for DMR mode
+    bit HMRDmrTimingDivEnabled;
+    // Number of delay cycles for DMR Timing Diversity mode
+    byte_t HMRDmrTimingDivDelays;
     // Enable ECC
     bit EnableECC;
     // Enable ECC on the hci interconnect
@@ -230,6 +234,8 @@ package pulp_cluster_package;
     HMRSeparateDataVoters: 1,
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
+    HMRDmrTimingDivEnabled: 0,
+    HMRDmrTimingDivDelays: 2,
     EnableECC: 1,
     ECCInterco: 1,
     iCacheNumBanks: 2,

--- a/packages/pulp_cluster_package.sv
+++ b/packages/pulp_cluster_package.sv
@@ -100,8 +100,6 @@ package pulp_cluster_package;
     bit HMRSeparateAxiBus;
     // Number of separate voters/checkers for individual buses
     bit HMRNumBusVoters;
-    // Enable Timing Diversity for DMR mode
-    bit HMRDmrTimingDivEnabled;
     // Number of delay cycles for DMR Timing Diversity mode
     byte_t HMRDmrTimingDivDelays;
     // Enable ECC
@@ -234,7 +232,6 @@ package pulp_cluster_package;
     HMRSeparateDataVoters: 1,
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
-    HMRDmrTimingDivEnabled: 0,
     HMRDmrTimingDivDelays: 2,
     EnableECC: 1,
     ECCInterco: 1,

--- a/packages/pulp_cluster_package.sv
+++ b/packages/pulp_cluster_package.sv
@@ -102,6 +102,8 @@ package pulp_cluster_package;
     bit HMRNumBusVoters;
     // Number of delay cycles for DMR Timing Diversity mode
     byte_t HMRDmrTimingDivDelays;
+    // Parameter for supporting DMR Timing Diversity in HMR Unit
+    bit DMRTimingDivSupported;
     // Enable ECC
     bit EnableECC;
     // Enable ECC on the hci interconnect
@@ -232,7 +234,8 @@ package pulp_cluster_package;
     HMRSeparateDataVoters: 1,
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
-    HMRDmrTimingDivDelays: 2,
+    HMRDmrTimingDivDelays: 0,
+    DMRTimingDivSupported: 0,
     EnableECC: 1,
     ECCInterco: 1,
     iCacheNumBanks: 2,

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1121,6 +1121,8 @@ generate
       .SeparateData      ( Cfg.HMRSeparateDataVoters            ),
       .SeparateAxiBus    ( Cfg.HMRSeparateAxiBus                ),
       .NumBusVoters      ( Cfg.HMRNumBusVoters                  ),
+      .TimingDivMode     ( Cfg.HMRDmrTimingDivEnabled           ),
+      .TimingDivDelays   ( Cfg.HMRDmrTimingDivDelays            ),
       .all_inputs_t      ( core_inputs_t                        ),
       .nominal_outputs_t ( core_outputs_t                       ),
       .core_backup_t     ( core_backup_t                        ),

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -198,7 +198,7 @@ module pulp_cluster
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_wptr_i,
   input  logic [AsyncOutBDataWidth-1:0]          async_data_master_b_data_i,
   output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_rptr_o,
-  output logic [(Cfg.NumCores>>1)-1:0]           hmr_dmr_failure_to_OT_o
+  output logic [(Cfg.NumCores>>1)-1:0]           dmr_timing_diversity_failure_o
 );
 
 //Ensure that the input AXI ID width is big enough to accomodate the IDs of internal wiring
@@ -1164,7 +1164,7 @@ generate
       .core_nominal_outputs_i ( core2hmr     ),
       .core_bus_outputs_i     ( '0           ),
       .core_axi_outputs_i     ( '0           ),
-      .dmr_failure_to_OT_o    ( hmr_dmr_failure_to_OT_o )
+      .dmr_timing_diversity_failure_o    ( dmr_timing_diversity_failure_o )
     );
 
     `ifndef VERILATOR

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -197,7 +197,8 @@ module pulp_cluster
   // WRITE RESPONSE CHANNEL
   input  logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_wptr_i,
   input  logic [AsyncOutBDataWidth-1:0]          async_data_master_b_data_i,
-  output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_rptr_o
+  output logic [Cfg.AxiCdcLogDepth:0]            async_data_master_b_rptr_o,
+  output logic [(Cfg.NumCores>>1)-1:0]           hmr_dmr_failure_to_OT_o
 );
 
 //Ensure that the input AXI ID width is big enough to accomodate the IDs of internal wiring
@@ -1121,7 +1122,6 @@ generate
       .SeparateData      ( Cfg.HMRSeparateDataVoters            ),
       .SeparateAxiBus    ( Cfg.HMRSeparateAxiBus                ),
       .NumBusVoters      ( Cfg.HMRNumBusVoters                  ),
-      .TimingDivMode     ( Cfg.HMRDmrTimingDivEnabled           ),
       .TimingDivDelays   ( Cfg.HMRDmrTimingDivDelays            ),
       .all_inputs_t      ( core_inputs_t                        ),
       .nominal_outputs_t ( core_outputs_t                       ),
@@ -1162,7 +1162,8 @@ generate
       .core_inputs_o          ( hmr2core     ),
       .core_nominal_outputs_i ( core2hmr     ),
       .core_bus_outputs_i     ( '0           ),
-      .core_axi_outputs_i     ( '0           )
+      .core_axi_outputs_i     ( '0           ),
+      .dmr_failure_to_OT_o    ( hmr_dmr_failure_to_OT_o )
     );
 
     `ifndef VERILATOR

--- a/rtl/pulp_cluster.sv
+++ b/rtl/pulp_cluster.sv
@@ -1123,6 +1123,7 @@ generate
       .SeparateAxiBus    ( Cfg.HMRSeparateAxiBus                ),
       .NumBusVoters      ( Cfg.HMRNumBusVoters                  ),
       .TimingDivDelays   ( Cfg.HMRDmrTimingDivDelays            ),
+      .DMRTimingDivSupported ( Cfg.DMRTimingDivSupported        ),
       .all_inputs_t      ( core_inputs_t                        ),
       .nominal_outputs_t ( core_outputs_t                       ),
       .core_backup_t     ( core_backup_t                        ),

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -317,6 +317,7 @@ module pulp_cluster_tb;
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
     HMRDmrTimingDivDelays: 0,
+    DMRTimingDivSupported: 0,
     EnableECC: 1,
     ECCInterco: 1,
     iCacheNumBanks: 2,

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -316,7 +316,6 @@ module pulp_cluster_tb;
     HMRSeparateDataVoters: 1,
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
-    HMRDmrTimingDivEnabled: 0,
     HMRDmrTimingDivDelays: 0,
     EnableECC: 1,
     ECCInterco: 1,
@@ -425,7 +424,8 @@ module pulp_cluster_tb;
     .async_data_slave_r_data_o   ( async_soc_to_cluster_axi_bus.r_data  ),
     .async_data_slave_b_wptr_o   ( async_soc_to_cluster_axi_bus.b_wptr  ),
     .async_data_slave_b_rptr_i   ( async_soc_to_cluster_axi_bus.b_rptr  ),
-    .async_data_slave_b_data_o   ( async_soc_to_cluster_axi_bus.b_data  )
+    .async_data_slave_b_data_o   ( async_soc_to_cluster_axi_bus.b_data  ),
+    .hmr_dmr_failure_to_OT_o     (                                      )
   );
 
   // Load ELF binary file

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -316,6 +316,8 @@ module pulp_cluster_tb;
     HMRSeparateDataVoters: 1,
     HMRSeparateAxiBus: 0,
     HMRNumBusVoters: 1,
+    HMRDmrTimingDivEnabled: 0,
+    HMRDmrTimingDivDelays: 0,
     EnableECC: 1,
     ECCInterco: 1,
     iCacheNumBanks: 2,

--- a/tb/pulp_cluster_tb.sv
+++ b/tb/pulp_cluster_tb.sv
@@ -426,7 +426,7 @@ module pulp_cluster_tb;
     .async_data_slave_b_wptr_o   ( async_soc_to_cluster_axi_bus.b_wptr  ),
     .async_data_slave_b_rptr_i   ( async_soc_to_cluster_axi_bus.b_rptr  ),
     .async_data_slave_b_data_o   ( async_soc_to_cluster_axi_bus.b_data  ),
-    .hmr_dmr_failure_to_OT_o     (                                      )
+    .dmr_timing_diversity_failure_o (                                      )
   );
 
   // Load ELF binary file


### PR DESCRIPTION
- [x] RTL TESTING: this one seems ok, I tried the fault injection script with the timing diversity feature enabled and we're able to detect mismatches which will be sent to OpenTitan
- [ ] IMPLEMENTATION: yet to be launched