### PR TITLE
[MAKEFILE] Bump regression_tests to fix idma_{2d,3d} and add idma tests to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endef
 ######################
 
 NONFREE_REMOTE ?= git@gitlab.chips.it:digitalresearchline/chips-restricted/pulp-cluster-nonfree.git
-NONFREE_COMMIT ?= 40971cff1fb9c0c2c8064bf3d3ca79dce1ce4cdc
+NONFREE_COMMIT ?= 05c9c686130a51302091df5676cbf7a13c298f5e
 
 nonfree-init:
 	git clone $(NONFREE_REMOTE) nonfree
@@ -98,7 +98,7 @@ fault_injection_sim:
 
 ## Clone regression tests
 REGRESSION_TESTS_REMOTE ?= https://github.com/FondazioneChipsIT/regression_tests.git
-REGRESSION_TESTS_COMMIT ?= dd41d893ee371df7407ce2c0128d2d3a45c4ec71 # branch: chips-it
+REGRESSION_TESTS_COMMIT ?= a795d6a318c5aa5842e61e2e2daf2d2c6cb89454 # branch: chips-it
 
 regression_tests:
 	git clone $(REGRESSION_TESTS_REMOTE) $@


### PR DESCRIPTION
This PR: 

- Introduces small fixes for idma_{2d,3d} tests in `regression_tests`
- Adds iDMA tests to CI flow (`nonfree`)